### PR TITLE
8: Renaming package to adhere to julia package naming conventions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "BayesSafetySignalDetect"
+name = "SafetySignalDetection"
 uuid = "ad9a3248-762c-4ade-a843-8f185e2c18ff"
 authors = ["Daniel Sabanes Bove <daniel.sabanes_bove@roche.com>", "Kristian Brock <kristian.brock@gmail.com>"]
 version = "0.0.1"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BayesSafetySignalDetect.jl
+# SafetySignalDetection.jl
 
 Bayesian Safety Signal Detection in Julia
 


### PR DESCRIPTION
closes #8

Once merged, I can also rename the GitHub repo accordingly.
